### PR TITLE
Scala 2.12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 [![Build Status](https://travis-ci.org/cloudinary/cloudinary_scala.svg)](https://travis-ci.org/cloudinary/cloudinary_scala)
 
+Kinja Custom Build
+==================
+
+This is a custom-built version of the Cloudinary Scala library. No changes are done in the logic, only a few dependencies
+are upgraded and cross-compilation is set up for Scala 2.11 and 2.12. This is no longer necessary as soon as Cloudinary
+releases a Scala 2.12 build.
+https://github.com/cloudinary/cloudinary_scala/pull/24
+https://github.com/cloudinary/cloudinary_scala/pull/27
+
+There's no Jenkins job for this project and we only need cloudinary_core so publish it to jFrog like this:
+
+```
+sbt> project cloudinaryCoreScala
+sbt> ++2.11.8
+sbt> publish
+sbt> ++2.12.6
+sbt> publish
+```
+
+
 Cloudinary
 ==========
 

--- a/cloudinary-core/build.sbt
+++ b/cloudinary-core/build.sbt
@@ -36,15 +36,21 @@ pomExtra := {
   
 libraryDependencies ++= Seq(
   "com.ning" % "async-http-client" % "1.9.40",
-  "org.json4s" %% "json4s-native" % "3.4.0",
-  "org.json4s" %% "json4s-ext" % "3.4.0",
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "org.nanohttpd" % "nanohttpd" % "2.2.0" % "test")
+  "org.json4s" %% "json4s-native" % "3.5.3",
+  "org.json4s" %% "json4s-ext" % "3.5.3",
+  "org.scalatest" %% "scalatest" % "3.0.4" % "test",
+  "org.nanohttpd" % "nanohttpd" % "2.3.1" % "test")
 
 // http://mvnrepository.com/artifact/org.slf4j/slf4j-simple
-libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.21" % "test"
-libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test"
+libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25" % "test"
+libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test"
 resolvers ++= Seq("sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots", "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
+credentials ++= Seq(Credentials(Path.userHome / ".ivy2" / ".kinja-artifactory.credentials"))
+
+publishTo := (
+  if (version.value endsWith "SNAPSHOT") Some("Kinja Snapshots" at sys.env.get("KINJA_SNAPSHOTS_REPO").getOrElse("https://kinjajfrog.jfrog.io/kinjajfrog/kinja-local-snapshots/"))
+  else Some("Kinja Releases" at sys.env.get("KINJA_RELEASES_REPO").getOrElse("https://kinjajfrog.jfrog.io/kinjajfrog/kinja-local-releases/"))
+)

--- a/cloudinary-core/project/build.properties
+++ b/cloudinary-core/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/cloudinary-core/src/main/scala/com/cloudinary/Url.scala
+++ b/cloudinary-core/src/main/scala/com/cloudinary/Url.scala
@@ -144,10 +144,7 @@ case class Url(
     }
     val prefix = getPrefix(source)
 
-    val version = (if (source.contains("/") && 
-                      !source.matches("v[0-9]+.*") && 
-                      !source.matches("https?:/.*") && 
-                      this.version.isEmpty) Some("1") else this.version).map("v" + _)
+    val version = this.version.map("v" + _)
 
     val (finalSource, signableSource) = finalizeSource(source)
 

--- a/cloudinary-core/src/test/scala/com/cloudinary/CloudinarySpec.scala
+++ b/cloudinary-core/src/test/scala/com/cloudinary/CloudinarySpec.scala
@@ -192,9 +192,12 @@ class CloudinarySpec extends FlatSpec with Matchers with OptionValues with Insid
 
   }
 
-  it should "add version if public_id contains" in {
+  it should "not add version if public_id contains folder and version not defined" in {
     cloudinary.url().generate("folder/test") should equal(
-      "http://res.cloudinary.com/test123/image/upload/v1/folder/test")
+      "http://res.cloudinary.com/test123/image/upload/folder/test")
+  }
+
+  it should "add version if public_id contains folder and version defined" in {
     cloudinary.url().version(123).generate("folder/test") should equal(
       "http://res.cloudinary.com/test123/image/upload/v123/folder/test")
   }
@@ -202,6 +205,13 @@ class CloudinarySpec extends FlatSpec with Matchers with OptionValues with Insid
   it should "not add version if public_id contains version already" in {
     cloudinary.url().generate("v123/test") should equal(
       "http://res.cloudinary.com/test123/image/upload/v123/test")
+    cloudinary.url().generate("v123/folder/test") should equal(
+      "http://res.cloudinary.com/test123/image/upload/v123/folder/test")
+  }
+
+  it should "not add version if public_id not contains folder and version not defined" in {
+    cloudinary.url().generate("test") should equal(
+      "http://res.cloudinary.com/test123/image/upload/test")
   }
 
   it should "allow to shorten image/upload urls" in {

--- a/cloudinary-play-plugin/project/build.properties
+++ b/cloudinary-play-plugin/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,6 @@
 object Common {
-  def version = "1.1.2"  
-  def playVersion = System.getProperty("play.version", "2.4.2")
-  def scalaVersion =  "2.11.5"
-  def scalaVersions =  Seq("2.10.4", scalaVersion)
+  def version = "1.1.2-kinja"  
+  def playVersion = System.getProperty("play.version", "2.6.13")
+  def scalaVersion =  "2.12.6"
+  def scalaVersions =  Seq("2.11.8", scalaVersion)
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,5 +1,5 @@
 object Common {
-  def version = "1.1.2-kinja"  
+  def version = "1.1.3-kinja"
   def playVersion = System.getProperty("play.version", "2.6.13")
   def scalaVersion =  "2.12.6"
   def scalaVersions =  Seq("2.11.8", scalaVersion)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.4.2"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.6.13"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")
 

--- a/samples/photo_album/project/build.properties
+++ b/samples/photo_album/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.16


### PR DESCRIPTION
**This is version 1.1.2, the same as what we use, while master is already newer, so this PR is not supposed to be merged!**

**Do not merge this PR!** This is a custom-built version of the Cloudinary Scala library. No changes are done in the logic, only a few dependencies are upgraded and cross-compilation is set up for Scala 2.11 and 2.12. This is no longer necessary as soon as Cloudinary releases a Scala 2.12 build.

There's no Jenkins job for this project and we only need cloudinary_core so publish it to jFrog like this:

```
sbt> project cloudinaryCoreScala
sbt> ++2.11.8
sbt> publish
sbt> ++2.12.6
sbt> publish
```

Here's the original 1.1.2: https://github.com/gawkermedia/cloudinary_scala/commit/0bc0d3d
And the diff: https://github.com/gawkermedia/cloudinary_scala/compare/0bc0d3d...1.1.2-kinja