### PR TITLE
1.1.3-kinja:  Fixing unwanted versioning

### DIFF
--- a/cloudinary-core/src/main/scala/com/cloudinary/Url.scala
+++ b/cloudinary-core/src/main/scala/com/cloudinary/Url.scala
@@ -144,10 +144,7 @@ case class Url(
     }
     val prefix = getPrefix(source)
 
-    val version = (if (source.contains("/") && 
-                      !source.matches("v[0-9]+.*") && 
-                      !source.matches("https?:/.*") && 
-                      this.version.isEmpty) Some("1") else this.version).map("v" + _)
+    val version = this.version.map("v" + _)
 
     val (finalSource, signableSource) = finalizeSource(source)
 

--- a/cloudinary-core/src/test/scala/com/cloudinary/CloudinarySpec.scala
+++ b/cloudinary-core/src/test/scala/com/cloudinary/CloudinarySpec.scala
@@ -192,9 +192,12 @@ class CloudinarySpec extends FlatSpec with Matchers with OptionValues with Insid
 
   }
 
-  it should "add version if public_id contains" in {
+  it should "not add version if public_id contains folder and version not defined" in {
     cloudinary.url().generate("folder/test") should equal(
-      "http://res.cloudinary.com/test123/image/upload/v1/folder/test")
+      "http://res.cloudinary.com/test123/image/upload/folder/test")
+  }
+
+  it should "add version if public_id contains folder and version defined" in {
     cloudinary.url().version(123).generate("folder/test") should equal(
       "http://res.cloudinary.com/test123/image/upload/v123/folder/test")
   }
@@ -202,6 +205,13 @@ class CloudinarySpec extends FlatSpec with Matchers with OptionValues with Insid
   it should "not add version if public_id contains version already" in {
     cloudinary.url().generate("v123/test") should equal(
       "http://res.cloudinary.com/test123/image/upload/v123/test")
+    cloudinary.url().generate("v123/folder/test") should equal(
+      "http://res.cloudinary.com/test123/image/upload/v123/folder/test")
+  }
+
+  it should "not add version if public_id not contains folder and version not defined" in {
+    cloudinary.url().generate("test") should equal(
+      "http://res.cloudinary.com/test123/image/upload/test")
   }
 
   it should "allow to shorten image/upload urls" in {

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,5 +1,5 @@
 object Common {
-  def version = "1.1.2-kinja"  
+  def version = "1.1.3-kinja"
   def playVersion = System.getProperty("play.version", "2.6.13")
   def scalaVersion =  "2.12.6"
   def scalaVersions =  Seq("2.11.8", scalaVersion)


### PR DESCRIPTION
Fixing unwanted versioning

Detailed description of the BUG:
If a cloudinary id contains slash like "qa/3655675" then during the url generation a default version `v1` generated into the url which can lead an unwanted version of the image:
https://i.kinja-img.com/gawker-media/image/upload/s--f8cjIVdR--/c_fill,fl_progressive,g_center,h_900,q_80,w_1600/v1/qa/3655675.jpg
vs
https://i.kinja-img.com/gawker-media/image/upload/s--f8cjIVdR--/c_fill,fl_progressive,g_center,h_900,q_80,w_1600/qa/3655675.jpg

This can happen if a video thumbnail is updated in MCP, the id stays the same but the content is updated.

Asana Ticket:
https://app.asana.com/0/419456048135282/1115870584175636