### PR TITLE
Scala 2.13 support

### DIFF
--- a/cloudinary-core/build.sbt
+++ b/cloudinary-core/build.sbt
@@ -35,15 +35,16 @@ pomExtra := {
 }  
   
 libraryDependencies ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
   "com.ning" % "async-http-client" % "1.9.40",
-  "org.json4s" %% "json4s-native" % "3.5.3",
-  "org.json4s" %% "json4s-ext" % "3.5.3",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test",
+  "org.json4s" %% "json4s-native" % "3.6.7",
+  "org.json4s" %% "json4s-ext" % "3.6.7",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "org.nanohttpd" % "nanohttpd" % "2.3.1" % "test")
 
 // http://mvnrepository.com/artifact/org.slf4j/slf4j-simple
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25" % "test"
-libraryDependencies += "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test"
+libraryDependencies += "org.scalamock" %% "scalamock" % "4.3.0" % "test"
 resolvers ++= Seq("sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots", "sonatype releases" at "https://oss.sonatype.org/content/repositories/releases")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")

--- a/cloudinary-core/src/main/scala/com/cloudinary/Api.scala
+++ b/cloudinary-core/src/main/scala/com/cloudinary/Api.scala
@@ -244,7 +244,7 @@ class Api(implicit cloudinary: Cloudinary) {
 
   def updateUploadPreset(uploadPreset: UploadPreset) = {
     callApi[UploadPresetUpdateResponse](Api.PUT, "upload_presets" :: uploadPreset.name :: Nil,
-      uploadPreset.toMap.filterKeys{_ != "name"})
+      uploadPreset.toMap.filter{ case (key, _) => key != "name"})
   }
 
   def rootFolders() = callApi[FolderListResponse](Api.GET, "folders" :: Nil, Map())

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,6 +1,6 @@
 object Common {
-  def version = "1.3.0"
+  def version = "1.3.1"
   def playVersion = System.getProperty("play.version", "2.6.13")
-  def scalaVersion =  "2.12.6"
-  def scalaVersions =  Seq("2.11.8", scalaVersion)
+  def scalaVersion =  "2.12.8"
+  def scalaVersions =  Seq("2.11.12", "2.13.0", scalaVersion)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.6.13"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.7.2"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0")
 


### PR DESCRIPTION
Minimal changes to make `cloudinary-core-scala` compile under 2.13. 

What didn't change since prev. version: `cloudinary-scala-play` doesn't  compile, some tests don't work